### PR TITLE
Fix GitHub blob URL parsing for branch names containing /

### DIFF
--- a/content.js
+++ b/content.js
@@ -23,14 +23,67 @@
     setTimeout(init, 500);
   }
 
-  async function init() {
-    const pathParts = window.location.pathname.split('/').filter(Boolean);
-    if (pathParts.length < 5) return; 
+  function parseGitHubBlobContext(pathname, doc) {
+    const pathParts = pathname.split('/').filter(Boolean);
+    if (pathParts.length < 5 || pathParts[2] !== 'blob') return null;
 
-    const owner = pathParts[0];
-    const repo = pathParts[1];
-    const branch = pathParts[3];
-    const filePath = pathParts.slice(4).join('/');
+    const fallback = {
+      owner: pathParts[0],
+      repo: pathParts[1],
+      branch: pathParts[3],
+      filePath: pathParts.slice(4).join('/')
+    };
+
+    if (!doc || typeof doc.querySelector !== 'function') {
+      return fallback;
+    }
+
+    const refSelector = doc.querySelector('button[data-testid="anchor-button"][aria-label$=" branch"], button[data-testid="anchor-button"][aria-label$=" tag"]');
+    const refLabel = refSelector?.getAttribute('aria-label');
+    if (refLabel) {
+      const branch = refLabel.replace(/ (branch|tag)$/, '');
+      const combinedPath = pathParts.slice(3).join('/');
+      const prefix = `${branch}/`;
+      if (combinedPath.startsWith(prefix)) {
+        return {
+          owner: pathParts[0],
+          repo: pathParts[1],
+          branch,
+          filePath: combinedPath.slice(prefix.length)
+        };
+      }
+    }
+
+    const embeddedDataScript = doc.querySelector('script[data-target="react-app.embeddedData"]');
+    if (!embeddedDataScript || !embeddedDataScript.textContent) {
+      return fallback;
+    }
+
+    try {
+      const embeddedData = JSON.parse(embeddedDataScript.textContent);
+      const layoutRoute = embeddedData?.payload?.codeViewLayoutRoute;
+      const blobRoute = embeddedData?.payload?.codeViewBlobLayoutRoute;
+      const owner = layoutRoute?.repo?.ownerLogin;
+      const repo = layoutRoute?.repo?.name;
+      const branch = blobRoute?.refInfo?.name || layoutRoute?.refInfo?.name;
+      const filePath = blobRoute?.path || layoutRoute?.path;
+
+      if (!owner || !repo || !branch || !filePath) {
+        return fallback;
+      }
+
+      return { owner, repo, branch, filePath };
+    } catch (err) {
+      console.warn('Affi: Could not parse GitHub embedded blob data', err);
+      return fallback;
+    }
+  }
+
+  async function init() {
+    const blobContext = parseGitHubBlobContext(window.location.pathname, document);
+    if (!blobContext) return;
+
+    const { owner, repo, branch, filePath } = blobContext;
     const isOwnersFile = filePath.endsWith('OWNERS');
     const isAliasesFile = filePath.endsWith('OWNERS_ALIASES');
 
@@ -346,7 +399,8 @@
   // Export functions for testing if we are in a Node environment
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-      fetchOwnersHierarchy
+      fetchOwnersHierarchy,
+      parseGitHubBlobContext
     };
   }
 })();

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,4 +1,4 @@
-const { fetchOwnersHierarchy } = require('../content.js');
+const { fetchOwnersHierarchy, parseGitHubBlobContext } = require('../content.js');
 // Mocking global functions used in fetchOwnersHierarchy
 global.shouldTruncate = require('../parser.js').shouldTruncate;
 global.jsyaml = require('../js-yaml.min.js');
@@ -35,6 +35,143 @@ describe('Affi Content Script - Hierarchy logic', () => {
       expect(result.truncated).toBe(true);
       expect(result.files[0].path).toBe('pkg');
       expect(result.files[1].path).toBe('pkg/probe');
+    });
+  });
+
+  describe('parseGitHubBlobContext', () => {
+    test('parses a standard blob URL without embedded data', () => {
+      const result = parseGitHubBlobContext('/kubernetes/kubernetes/blob/main/pkg/probe/OWNERS');
+
+      expect(result).toEqual({
+        owner: 'kubernetes',
+        repo: 'kubernetes',
+        branch: 'main',
+        filePath: 'pkg/probe/OWNERS'
+      });
+    });
+
+    test('prefers the branch selector in the DOM when a slash branch is shown in the UI', () => {
+      const doc = {
+        querySelector: jest.fn((selector) => {
+          if (selector.includes('button[data-testid="anchor-button"]')) {
+            return {
+              getAttribute: jest.fn().mockReturnValue('feature/foo branch')
+            };
+          }
+          return null;
+        })
+      };
+
+      const result = parseGitHubBlobContext('/kubernetes/kubernetes/blob/feature/foo/pkg/probe/OWNERS', doc);
+
+      expect(result).toEqual({
+        owner: 'kubernetes',
+        repo: 'kubernetes',
+        branch: 'feature/foo',
+        filePath: 'pkg/probe/OWNERS'
+      });
+    });
+
+    test('parses tag labels from the DOM ref selector', () => {
+      const doc = {
+        querySelector: jest.fn((selector) => {
+          if (selector.includes('button[data-testid="anchor-button"]')) {
+            return {
+              getAttribute: jest.fn().mockReturnValue('release-1.35/foo tag')
+            };
+          }
+          return null;
+        })
+      };
+
+      const result = parseGitHubBlobContext('/kubernetes/kubernetes/blob/release-1.35/foo/OWNERS_ALIASES', doc);
+
+      expect(result).toEqual({
+        owner: 'kubernetes',
+        repo: 'kubernetes',
+        branch: 'release-1.35/foo',
+        filePath: 'OWNERS_ALIASES'
+      });
+    });
+
+    test('prefers embedded data when the branch name contains a slash', () => {
+      const doc = {
+        querySelector: jest.fn((selector) => {
+          if (selector.includes('button[data-testid="anchor-button"]')) {
+            return null;
+          }
+          if (selector === 'script[data-target="react-app.embeddedData"]') {
+            return {
+              textContent: JSON.stringify({
+                payload: {
+                  codeViewLayoutRoute: {
+                    repo: {
+                      ownerLogin: 'kubernetes',
+                      name: 'kubernetes'
+                    }
+                  },
+                  codeViewBlobLayoutRoute: {
+                    refInfo: {
+                      name: 'feature/foo'
+                    },
+                    path: 'pkg/probe/OWNERS'
+                  }
+                }
+              })
+            };
+          }
+          return null;
+        })
+      };
+
+      const result = parseGitHubBlobContext('/kubernetes/kubernetes/blob/feature/foo/pkg/probe/OWNERS', doc);
+
+      expect(result).toEqual({
+        owner: 'kubernetes',
+        repo: 'kubernetes',
+        branch: 'feature/foo',
+        filePath: 'pkg/probe/OWNERS'
+      });
+    });
+
+    test('parses OWNERS_ALIASES from embedded data when the branch name contains a slash', () => {
+      const doc = {
+        querySelector: jest.fn((selector) => {
+          if (selector.includes('button[data-testid="anchor-button"]')) {
+            return null;
+          }
+          if (selector === 'script[data-target="react-app.embeddedData"]') {
+            return {
+              textContent: JSON.stringify({
+                payload: {
+                  codeViewLayoutRoute: {
+                    repo: {
+                      ownerLogin: 'kubernetes',
+                      name: 'kubernetes'
+                    }
+                  },
+                  codeViewBlobLayoutRoute: {
+                    refInfo: {
+                      name: 'release-1.35/foo'
+                    },
+                    path: 'OWNERS_ALIASES'
+                  }
+                }
+              })
+            };
+          }
+          return null;
+        })
+      };
+
+      const result = parseGitHubBlobContext('/kubernetes/kubernetes/blob/release-1.35/foo/OWNERS_ALIASES', doc);
+
+      expect(result).toEqual({
+        owner: 'kubernetes',
+        repo: 'kubernetes',
+        branch: 'release-1.35/foo',
+        filePath: 'OWNERS_ALIASES'
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fix parsing of GitHub blob URLs when the branch name contains `/`. Previously we assumed the branch name was a single path segment, which produced incorrect raw file URLs for branches like `feature/foo`.

